### PR TITLE
Implement driver for ueye camera UI-3251LE-M-GL

### DIFF
--- a/src/ueye_camera.h
+++ b/src/ueye_camera.h
@@ -69,14 +69,17 @@ public:
 	 * @param[in] aoi_ratio Area Of Interest (AOI) ratio in [0,1] from image centre
 	 * @throws std::exception if connection to camera fails
 	 */
-	Camera( const UEYE_CAMERA_INFO& camera_info, int32_t format_id, float frame_rate, 
-	    const std::string& color_mode, float aoi_ratio );
-
+	Camera( const UEYE_CAMERA_INFO& device_info, double frame_rate, double &publish_rate,
+			const std::string& color_mode, UINT _pixelclock);
 	virtual ~Camera();
 
 	std::string get_calibration_file() const;
     const sensor_msgs::CameraInfo& get_info() const { return camera_info_; }
 	bool set_master_gain( uint8_t master_gain ); // in [0,100]
+	bool set_exposure( double exposure );
+	bool set_blacklevel(INT nOffset);
+	bool set_gamma(INT nGamma);
+	bool set_hardware_gamma();
 	void start_capture( bool external_trigger );
     
 	/**

--- a/src/ueye_driver.cpp
+++ b/src/ueye_driver.cpp
@@ -15,27 +15,51 @@ int main( int argc, char** argv )
 	ros::init( argc, argv, ROS_PACKAGE_NAME, ros::init_options::NoSigintHandler );
 	ros::NodeHandle nh, local_nh("~");
 
-	bool external_trigger = false;
-	float frame_rate, publish_rate, aoi_ratio;
-	int camera_id, master_gain, image_format, timeout_ms;
+	bool external_trigger = false, hard_gamma = false;
+	int camera_id, master_gain, timeout_ms, pixelclock;
 	std::string camera_name, color_mode, image_topic;
+	double exposure, frame_rate, publish_rate;
+	INT nOffset, n_gamma ;
 
 	local_nh.param<int>( "camera_id", camera_id, 0 );
+	local_nh.param<int>( "pixelclock", pixelclock, 84 );
+	local_nh.param<double>( "exposure", exposure, 40 );
+	local_nh.param<int>( "blacklevel", nOffset, 90 );
+	local_nh.param<int>( "gamma", n_gamma, 100 );
+	local_nh.param<bool>( "hardware_gamma", hard_gamma, false );
 	local_nh.param<int>( "master_gain", master_gain, 0 );
-	local_nh.param<int>( "image_format", image_format, 20 );
+//	local_nh.param<int>( "image_format", image_format, 20 );
 	local_nh.param<int>( "timeout_ms", timeout_ms, 100 );
 	local_nh.param<bool>( "external_trigger", external_trigger, false );
-	local_nh.param<float>( "frame_rate", frame_rate, 30 );
-	local_nh.param<float>( "publish_rate", publish_rate, frame_rate );
-	local_nh.param<float>( "aoi_ratio", aoi_ratio, 1.0 );
+	//The key "frame_rate" is apparently already set in local_nh, so I use "fps".
+	local_nh.param<double>( "fps", frame_rate, 25 );
+	local_nh.param<double>( "publish_rate", publish_rate, frame_rate );
+//	local_nh.param<float>( "aoi_ratio", aoi_ratio, 1.0 );
 	local_nh.param<std::string>( "camera_name", camera_name, "camera" );
 	local_nh.param<std::string>( "image_topic", image_topic, "image_raw" );
 	local_nh.param<std::string>( "color_mode", color_mode, "mono8" );
 
+	ROS_INFO("CAMERA PARAMETERS - SETTINGS");
+	ROS_INFO("pixelclock to be set to %d MHz \t [1 - 128] MHz", pixelclock);
+	ROS_INFO("fps to be set to %.1f Hz \t [Range depends on pixel clock, AOI, resolution]", frame_rate);
+	ROS_INFO("exposure to be set to %.1f ms \t [Range depends on frame rate]", exposure);
+	ROS_INFO("blacklevel to be set to %d  \t [0 - 255]", nOffset);
+	ROS_INFO("gamma to be set to %d  \t [1 - 1000]", n_gamma);
+	std::string msg_hard_g = (hard_gamma ? "Hardware gamma to be set" : "Hardware gamma not to be set");
+	ROS_INFO("%s", msg_hard_g.c_str());
+	ROS_INFO("master_gain to be set to %d  \t [0 - 100] %% \n", master_gain);
+
+	ROS_INFO("PUBLISH INFO ");
+	ROS_INFO("Timeout set to %d ms", timeout_ms);
+	std::string msg_trigg = (external_trigger ? "External trigger set" : "Free run mode set");
+	ROS_INFO("%s", msg_trigg.c_str());
+	ROS_INFO("Publish_rate to be set to %.1f \t [equals frame rate desired]", publish_rate);
+	ROS_INFO("Camera name set to %s", camera_name.c_str());
+	ROS_INFO("Image topic set to %s", image_topic.c_str());
+	ROS_INFO("Color mode set to %s \n", color_mode.c_str());
+
 	image_transport::ImageTransport it(nh);
 	auto pub = it.advertiseCamera( camera_name + "/" + image_topic, 1 );
-
-	ros::Rate spinner(publish_rate);
 
 	auto available_cameras = ueye::Camera::get_camera_list();
 	ROS_INFO("found %lu available cameras", available_cameras.size() );
@@ -49,9 +73,18 @@ int main( int argc, char** argv )
 	if ( camera_info == available_cameras.end() ) 
 		{ ROS_ERROR("invalid camera id"); return 0; }
 	
-	ueye::Camera camera( *camera_info, image_format, frame_rate, color_mode, aoi_ratio );
+	ueye::Camera camera( *camera_info, frame_rate, publish_rate, color_mode, pixelclock) ;
 
+	ROS_INFO("Publish_rate set to %.1f \t [equals frame actual frame rate set]", publish_rate);
+	ros::Rate spinner(publish_rate);
+
+	camera.set_exposure( exposure );
 	camera.set_master_gain( master_gain );
+	camera.set_blacklevel(nOffset);
+	/* set gamma value to 1.6 */
+	//	INT nGamma = 160;
+	camera.set_gamma(n_gamma);
+	if (hard_gamma) camera.set_hardware_gamma();
 	camera.start_capture( external_trigger );
 
 	while ( ros::ok() )


### PR DESCRIPTION
This driver is specifically tailored to work with the ueye camera UI-3251LE-M-GL,
and a fish-eye lens model Lensagon BF2M15520.

The driver creates a ROI for the area occupied for the lens, and allows
the configuration of the following parameters:

+pixel clock
+frame rate
+exposure
+black level offset
+gamma
+hardware gamma
+master gain

It publishes the video streamed by the camera to /camera/image_raw. It
also reads the calibration file but image_proc doesn't seem to be able
to rectify the images.
